### PR TITLE
Fix debugging support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,15 @@ GEM
   remote: http://rubygems.org/
   specs:
     archive-tar-minitar (0.5.2)
-    columnize (0.3.2)
+    columnize (0.3.4)
     diff-lcs (1.1.2)
-    linecache (0.45)
+    linecache (0.46)
+      rbx-require-relative (> 0.0.4)
     linecache19 (0.5.12)
       ruby_core_source (>= 0.1.4)
     mocha (0.9.12)
     rack (1.3.0)
+    rbx-require-relative (0.0.5)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
       rspec-expectations (~> 2.6.0)


### PR DESCRIPTION
Newer versions are needed for debugging to work properly. The error I got was:

```
betelgeuse@pena /mnt/checkouts/IMGKit $ bundle exec rdebug rspec tag wip
/home/betelgeuse/.gem/ruby/1.8/gems/linecache-0.45/lib/linecache.rb:66:in `require': no such file to load -- require_relative (LoadError)
        from /home/betelgeuse/.gem/ruby/1.8/gems/linecache-0.45/lib/linecache.rb:66
        from /usr/local/lib/ruby/gems/1.8/gems/ruby-debug-base-0.10.4/lib/ruby-debug-base.rb:3:in `require'
        from /usr/local/lib/ruby/gems/1.8/gems/ruby-debug-base-0.10.4/lib/ruby-debug-base.rb:3
        from /usr/local/lib/ruby/gems/1.8/gems/ruby-debug-0.10.4/cli/ruby-debug.rb:5:in `require'
        from /usr/local/lib/ruby/gems/1.8/gems/ruby-debug-0.10.4/cli/ruby-debug.rb:5
        from /usr/local/lib/ruby/gems/1.8/gems/ruby-debug-0.10.4/bin/rdebug:109:in `require'
        from /usr/local/lib/ruby/gems/1.8/gems/ruby-debug-0.10.4/bin/rdebug:109
        from /usr/local/bin/rdebug:19:in `load'
        from /usr/local/bin/rdebug:19

```
