### PR TITLE
Do not recognize HTML as a URL, even if it has an http line

### DIFF
--- a/lib/imgkit/source.rb
+++ b/lib/imgkit/source.rb
@@ -7,7 +7,7 @@ class IMGKit
     end
     
     def url?
-      @source.is_a?(String) && @source.match(/^http/)
+      @source.is_a?(String) && @source.match(/\Ahttp/)
     end
     
     def file?

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -17,6 +17,11 @@ describe IMGKit::Source do
       source = IMGKit::Source.new('<blink>Oh Hai!</blink>')
       source.should_not be_url
     end
+
+    it "should return false if passed HTML with a line starting with 'http'" do
+      source = IMGKit::Source.new("<blink>Oh Hai!</blink>\nhttp://google.com")
+      source.should_not be_url
+    end
   end
   
   describe "#file?" do


### PR DESCRIPTION
I've revised `Source#url?` to use `/\Ahttp/` as its regular expression, thus lowering the likelihood of a false positive, and included a spec for it in `source_spec.rb`.

This fixes csquared/IMGKit#11.

Thanks,
Chris
