### PR TITLE
Fixed installer for wkhtmltoimage when download uses bz2 architecture is...

### DIFF
--- a/bin/imgkit
+++ b/bin/imgkit
@@ -76,7 +76,7 @@ OptionParser.new do |parser|
   parser.on("--install-wkhtmltoimage", "Install wkhtmltoimage binaries (TO=/usr/local/bin ARCHITECTURE=i386)") do
     @command = Proc.new do
       architecture = ENV['ARCHITECTURE'] || detect_architecture
-      install_to = ENV['TO']+'wkhtmltoimage' || IMGKit.configuration.wkhtmltoimage
+      install_to = ENV['TO']+'/wkhtmltoimage' || IMGKit.configuration.wkhtmltoimage
       
       Dir.chdir '/tmp'
       


### PR DESCRIPTION
... still taken in consideration. Also when using TO=/usr/local/bin, wkhtmltoimage needs to be appended since folder is implied and not path.
