### PR TITLE
Don't use sudo and naming bug

### DIFF
--- a/bin/imgkit
+++ b/bin/imgkit
@@ -51,17 +51,17 @@ end
 def install(download, arch, install_to)
   puts "Installing #{download} to #{install_to}"
   if download =~ /.tar.bz2$/
-    `sudo tar xjvf #{download}`
-    `sudo mv wkhtmltoimage-#{arch} #{install_to}`
+    `tar xjvf #{download}`
+    `mv wkhtmltoimage #{install_to}`
   elsif download =~ /.tar.lzma$/
     raise "couldn't extract archive: lzcat not found" unless system("which lzcat > /dev/null 2>/dev/null")
     puts "Warning: lzcat is broken on Ubuntu. Re-run with --use-bzip to install alternate version"
-    `sudo lzcat #{download} | tar x`
-    `sudo mv wkhtmltoimage-#{arch} #{install_to}`
+    `lzcat #{download} | tar x`
+    `mv wkhtmltoimage-#{arch} #{install_to}`
   else
-    `sudo mv #{download} #{install_to}`
+    `mv #{download} #{install_to}`
   end
-  `sudo chmod +x #{install_to}`
+  `chmod +x #{install_to}`
 end
 
 @command = Proc.new { puts "Nothing to do: use --help"}
@@ -76,7 +76,7 @@ OptionParser.new do |parser|
   parser.on("--install-wkhtmltoimage", "Install wkhtmltoimage binaries (TO=/usr/local/bin ARCHITECTURE=i386)") do
     @command = Proc.new do
       architecture = ENV['ARCHITECTURE'] || detect_architecture
-      install_to = ENV['TO']+'/wkhtmltoimage' || IMGKit.configuration.wkhtmltoimage
+      install_to = ENV['TO'] ? ENV['TO']+'/wkhtmltoimage' : IMGKit.configuration.wkhtmltoimage
       
       Dir.chdir '/tmp'
       


### PR DESCRIPTION
I prepose not using sudo (the imgkit command can be run with sudo if necessary) and there is a bug with the name not having -#{arch} in it when it's unzipped in /tmp/.
