### PR TITLE
Flexible binary path search

### DIFF
--- a/lib/imgkit/configuration.rb
+++ b/lib/imgkit/configuration.rb
@@ -4,9 +4,10 @@ class IMGKit
 
     def initialize
       @meta_tag_prefix = 'imgkit-'
-      @wkhtmltoimage   = '/usr/local/bin/wkhtmltoimage'
       @default_options = {:height => 1000}
       @default_format  = :jpg
+      @wkhtmltoimage ||= (defined?(Bundler::GemfileError) ? `bundle exec which wkhtmltoimage` : `which wkhtmltoimage`).chomp
+      @wkhtmltoimage = '/usr/local/bin/wkhtmltoimage' if @wkhtmltoimage.strip.empty?  # Fallback
     end
   end
 


### PR DESCRIPTION
Hi,
I created a gem for the linux wkhtmltoimage binaries as seen for wkhtmltopdf.

To use it I also needed to change the path selection in IMGKit. This goes along with PDFKit too. It also keeps compatible with the normal way as it is now.

Since I guess this is useful for others too I'd love to see this merged and the gem updated at rubygem.org.

Thanks in advance for response.

wkhtmltoimage-binary gem:
https://rubygems.org/gems/wkhtmltoimage-binary
