### PR TITLE
Recognize that `TempFile` is a file.

### DIFF
--- a/lib/imgkit/source.rb
+++ b/lib/imgkit/source.rb
@@ -11,7 +11,7 @@ class IMGKit
     end
     
     def file?
-      @source.kind_of?(File)
+      @source.kind_of?(File) || @source.kind_of?(Tempfile)
     end
     
     def html?

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -29,6 +29,11 @@ describe IMGKit::Source do
       source = IMGKit::Source.new(File.new(__FILE__))
       source.should be_file
     end
+
+    it "should return true if passed a temporary file" do
+      source = IMGKit::Source.new(Tempfile.new 'temp_file')
+      source.should be_file
+    end
     
     it "should return false if passed a url like string" do
       source = IMGKit::Source.new('http://google.com')


### PR DESCRIPTION
Since `wkhtmltoimage` [has problem when HTML is passed in stdin](http://code.google.com/p/wkhtmltopdf/issues/detail?id=534), one solution is to store HTML in a temporary file, and pass this file to `IMGKit.new`.

This commit ensures that IMGKit accepts not only instances of `File`, but also of Ruby's `TempFile` as a way to declare that the HTML is stored inside a file.
