### PR TITLE
Refactor overriding of IMGKit::Configuration#wkhtmltoimage

### DIFF
--- a/lib/imgkit/configuration.rb
+++ b/lib/imgkit/configuration.rb
@@ -1,13 +1,25 @@
 class IMGKit
   class Configuration
-    attr_accessor :meta_tag_prefix, :wkhtmltoimage, :default_options, :default_format
+    attr_writer :wkhtmltoimage
+    attr_accessor :meta_tag_prefix, :default_options, :default_format
 
     def initialize
       @meta_tag_prefix = 'imgkit-'
       @default_options = {:height => 1000}
       @default_format  = :jpg
-      @wkhtmltoimage ||= (defined?(Bundler::GemfileError) ? `bundle exec which wkhtmltoimage` : `which wkhtmltoimage`).chomp
-      @wkhtmltoimage = '/usr/local/bin/wkhtmltoimage' if @wkhtmltoimage.strip.empty?  # Fallback
+    end
+
+    def wkhtmltoimage
+      @wkhtmltoimage ||= begin
+        path = (using_bundler? ? `bundle exec which wkhtmltoimage` : `which wkhtmltoimage`).chomp
+        path = '/usr/local/bin/wkhtmltoimage' if path.strip.empty?  # Fallback
+        path
+      end
+    end
+
+    private
+    def using_bundler?
+      defined?(Bundler::GemfileError)
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+describe IMGKit::Configuration do
+  describe "#wkhtmltoimage" do
+    context "system version exists" do
+      let(:system_path) { "/path/to/wkhtmltoimage\n" }
+
+      before(:each) do
+        subject.stub :` => system_path
+      end
+
+      context "with Bundler" do
+        before(:each) do
+          subject.stub :using_bundler? => true
+        end
+
+        it "should return the result of `bundle exec which wkhtmltoimage` with whitespace stripped" do
+          subject.should_receive(:`).with("bundle exec which wkhtmltoimage")
+          subject.wkhtmltoimage.should == system_path.chomp
+        end
+      end
+
+      context "without Bundler" do
+        before(:each) do
+          subject.stub :using_bundler? => false
+        end
+
+        it "should return the result of `which wkhtmltoimage` with whitespace stripped" do
+          subject.should_receive(:`).with("which wkhtmltoimage")
+          subject.wkhtmltoimage.should == system_path.chomp
+        end
+      end
+    end
+
+    context "system version does not exist" do
+      before(:each) do
+        subject.stub :` => "\n"
+        subject.stub :using_bundler? => false
+      end
+
+      it "should return the fallback path" do
+        subject.wkhtmltoimage.should == "/usr/local/bin/wkhtmltoimage"
+      end
+    end
+
+    context "set explicitly" do
+      let(:explicit_path) { "/explicit/path/to/wkhtmltoimage" }
+
+      before(:each) do
+        subject.wkhtmltoimage = explicit_path
+      end
+
+      it "should not check the system version and return the explicit path" do
+        subject.should_not_receive(:`)
+        subject.wkhtmltoimage.should == explicit_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this change, the initialize method would check the system for
paths to the wkhtmltoimage binary even if it will be overridden later.

With this change, we only check the system if @wkhtmltoimage hasn't been
explicitly set via the attr_writer.

Relates to #50
