### PR TITLE
Move tempfile require to lib

### DIFF
--- a/lib/imgkit.rb
+++ b/lib/imgkit.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'open3'
+require 'tempfile'
 require 'imgkit/source'
 require 'imgkit/imgkit'
 require 'imgkit/configuration'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require 'rspec'
 require 'rspec/autorun'
 require 'mocha'
 require 'rack'
-require 'tempfile'
 
 RSpec.configure do |config|
   config.before do
@@ -26,7 +25,7 @@ module MagicNumber
   GIF  = "\x47\x49\x46\x38"
 
 
-  if "".respond_to?(:force_encoding) 
+  if "".respond_to?(:force_encoding)
     constants.each { |c| const_get(c).force_encoding("ASCII-8BIT")  }
   end
 


### PR DESCRIPTION
Since tempfile should be required when using IMGKit it should be required by the lib and not only by the specs.
