### PR TITLE
Removed default to 1000px high

### DIFF
--- a/lib/imgkit/configuration.rb
+++ b/lib/imgkit/configuration.rb
@@ -5,7 +5,7 @@ class IMGKit
 
     def initialize
       @meta_tag_prefix = 'imgkit-'
-      @default_options = {:height => 1000}
+      @default_options = {:height => 0}
       @default_format  = :jpg
     end
 

--- a/spec/imgkit_spec.rb
+++ b/spec/imgkit_spec.rb
@@ -27,7 +27,7 @@ describe IMGKit do
     it "should set a default height" do
       imgkit = IMGKit.new('<h1>Oh Hai</h1>')
       imgkit.options.length.should be 1
-      imgkit.options[:height].should be 1000
+      imgkit.options[:height].should be 0
     end
 
 


### PR DESCRIPTION
The default should follow wkhtmltoimage's default, which 0 (automatic height)
