### PR TITLE
add height/width limit options to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ gem install wkhtmltoimage-binary
     # Add any kind of option through meta tags
     IMGKit.new('<html><head><meta name="imgkit-quality" content="75"...
 
+    # Image width/height limits options
+    IMGKit.new(self.html_body, quality: 50, width: 600, height: 800)
+
     # Format shortcuts - New in 1.3!
     IMGKit.new("hello").to_jpg
     IMGKit.new("hello").to_jpeg


### PR DESCRIPTION
couldn't find mention about this anywhere in the IMGkit docs or `wkhtmltoimage -H` and actually this works.

it's a life saver for my scenario https://gist.github.com/equivalent/27d4abbb78ea991778316526f87fff94#gistcomment-3366764