### PR TITLE
Fix `File.exists?` deprecation warning. Use `File.exist?` instead

### DIFF
--- a/lib/imgkit/imgkit.rb
+++ b/lib/imgkit/imgkit.rb
@@ -42,7 +42,7 @@ class IMGKit
     @options = IMGKit.configuration.default_options.merge(options)
     @options.merge! find_options_in_meta(url_file_or_html) unless source.url?
 
-    raise NoExecutableError.new unless File.exists?(IMGKit.configuration.wkhtmltoimage)
+    raise NoExecutableError.new unless File.exist?(IMGKit.configuration.wkhtmltoimage)
   end
 
   def command(output_file = nil)

--- a/spec/imgkit_spec.rb
+++ b/spec/imgkit_spec.rb
@@ -286,7 +286,7 @@ describe IMGKit do
       imgkit = IMGKit.new('html', :quality => 50)
       file = imgkit.to_file(@file_path)
       file.should be_instance_of(File)
-      File.exists?(file.path).should be_true
+      File.exist?(file.path).should be_true
     end
 
     IMGKit::KNOWN_FORMATS.each do |format|


### PR DESCRIPTION
Fixes https://github.com/csquared/IMGKit/issues/127